### PR TITLE
ci: move release workflow off self-hosted-gregor to ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   publish:
     name: Publish to Hex
-    runs-on: [self-hosted, self-hosted-gregor]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Elixir


### PR DESCRIPTION
## Summary
- Deprioritizes the self-hosted gregor runner (per infra issues tonight) and switches `.github/workflows/release.yml`'s `publish` job from `runs-on: [self-hosted, self-hosted-gregor]` to `runs-on: ubuntu-latest`, matching `elixir.yml`'s already-working github-hosted pattern.
- No other changes needed: the job already sets up the toolchain via `erlef/setup-beam@v1.18.1` with `elixir-version: "1.20"` / `otp-version: "29"` (matching `elixir.yml`'s pinned versions), and its cache steps already use plain `hashFiles()` — this file doesn't have the gregor-specific hand-computed-hash workaround merged into `main`, so there was nothing to revert there.
- `release.yml` only triggers on `release: published`, not `pull_request`, so the existing `merge_group` trigger requirement doesn't apply here.

## Test plan
- [x] `actionlint` passes on `release.yml` and `elixir.yml`
- [ ] CI on this PR runs green on `ubuntu-latest`
- [ ] A follow-up real `release` event confirms the Hex publish step still works end-to-end (org-level `HEX_API_KEY` secret unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYAU88WFwhxd4UmrGYvP7u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to run on GitHub-hosted infrastructure instead of a self-hosted runner, helping make releases more reliable and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->