### PR TITLE
chore: update post-transfer workflow references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   publish:
     name: Publish to Hex
-    runs-on: [self-hosted, self-hosted-gregor]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Elixir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,15 @@ jobs:
             echo "Tag version ($TAG_VERSION) does not match mix.exs version ($MIX_VERSION)"
             exit 1
           fi
+      - name: Load publish secrets
+        id: load_secrets
+        uses: 1password/load-secrets-action@v4
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          HEX_API_KEY: op://Github Secrets/HEX_API_KEY/credential
       - name: Publish to Hex
         uses: synchronal/hex-publish-action@v3
         with:
           name: newt
-          key: ${{ secrets.HEX_API_KEY }}
+          key: ${{ steps.load_secrets.outputs.HEX_API_KEY }}
           tag-release: false


### PR DESCRIPTION
Updates post-transfer repository references and moves workflow runtime secret access
to the shared 1Password `Github Secrets` vault.

This only changes repositories that were part of the `slipstream-eng` migration
inventory.

Secret-loading changes:

- keep `OP_SERVICE_ACCOUNT_TOKEN` as the only GitHub Actions bootstrap secret
- load runtime values with `1password/load-secrets-action@v4`
- use `op://Github Secrets/...` references for cargo/Hex publish tokens,
  the GitHub release automation PAT, and the release signing SSH key
- remove Codecov and OpenAI/Anthropic/Claude token usage from CI
- use npm trusted publishing/OIDC instead of `NPM_TOKEN`
- keep built-in `GITHUB_TOKEN` usage unchanged

Runner migration:

- replace `self-hosted-gregor` with `ubuntu-latest` where the transferred
  personal-account repos no longer have an eligible shared runner
- add the repo-standard Determinate Systems Nix installer/cache actions before
  `nix develop` steps where needed

Verification run where applicable:

- `git diff --check`
- YAML parse check with Python `yaml.safe_load`
- `actionlint`

Notes:

- Historical generated changelog links were left alone.
- Forgejo product/runtime references were left alone unless they pointed at
  migrated source repositories.
- The remaining 1Password runtime secrets are populated: Cargo, Hex, GitHub
  release automation PAT, and release signing key.
- `GH_RELEASE_AUTOMATION_TOKEN` is a fine-grained PAT. Required repository
  permissions: Contents read/write, Pull requests read/write, Issues read/write
  for release-please repos, Metadata read-only. Do not grant Actions/Workflows
  unless release automation must edit workflow files; do not grant
  Administration unless protected tag rules block release tag creation.
- npm packages must be configured in npm as trusted publishers for their
  GitHub repository and publish workflow before tokenless npm publishing works.
